### PR TITLE
Add date handler

### DIFF
--- a/src/main/java/wanted/commons/core/date/Date.java
+++ b/src/main/java/wanted/commons/core/date/Date.java
@@ -1,0 +1,55 @@
+package wanted.commons.core.date;
+
+import java.util.Objects;
+
+import wanted.commons.util.ToStringBuilder;
+
+/**
+ * Represents a date.
+ * <p>
+ * In the current implementation, a date is simply stored as a String,
+ * but it should be modified in the future so that it can:
+ * - reject invalid dates
+ * - convert to String in a specific format
+ * - calculate the difference of two dates
+ * etc.
+ */
+public class Date {
+    private final String date;
+
+    /**
+     * Constructs a {@code Date} with the given date.
+     *
+     * @param date The string representation of the date.
+     */
+    public Date(String date) {
+        this.date = date;
+    }
+
+    /**
+     * Returns the stored date.
+     */
+    public String getDate() {
+        return this.date;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Date)) {
+            return false;
+        }
+
+        Date otherDate = (Date) other;
+        return Objects.equals(date, otherDate.date);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("date", date).toString();
+    }
+}

--- a/src/main/java/wanted/logic/parser/ParserUtil.java
+++ b/src/main/java/wanted/logic/parser/ParserUtil.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import wanted.commons.core.date.Date;
 import wanted.commons.core.index.Index;
 import wanted.commons.util.StringUtil;
 import wanted.logic.parser.exceptions.ParseException;
@@ -33,6 +34,19 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses a {@code String date} into a {@code Date}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code date} is invalid.
+     */
+    public static Date parseDate(String date) throws ParseException {
+        requireNonNull(date);
+        String trimmedDate = date.trim();
+        // todo: We should have a validity check in the future.
+        return new Date(trimmedDate);
     }
 
     /**

--- a/src/test/java/wanted/commons/core/date/DateTest.java
+++ b/src/test/java/wanted/commons/core/date/DateTest.java
@@ -1,0 +1,45 @@
+package wanted.commons.core.date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class DateTest {
+
+    @Test
+    public void constructor() {
+        assertEquals("2025-01-01", new Date("2025-01-01").getDate());
+    }
+
+    @Test
+    public void equals() {
+        final Date date = new Date("1 Jan 2025");
+
+        // same values -> returns true
+        assertTrue(date.equals(new Date("1 Jan 2025")));
+
+        // same object -> returns true
+        assertTrue(date.equals(date));
+
+        // null -> returns false
+        assertFalse(date.equals(null));
+
+        // different types -> returns false
+        assertFalse(date.equals("1 Jan 2025"));
+
+        // different dates -> returns false
+        assertFalse(date.equals(new Date("1 Feb 2025")));
+
+        // same date but different formats -> returns false
+        assertFalse(date.equals(new Date("01-01-2025")));
+    }
+
+    @Test
+    public void toStringMethod() {
+        final Date date = new Date("1 Jan 2025");
+        String expected = Date.class.getCanonicalName() + "{date=" + date.getDate() + "}";
+        assertEquals(expected, date.toString());
+    }
+}

--- a/src/test/java/wanted/logic/parser/ParserUtilTest.java
+++ b/src/test/java/wanted/logic/parser/ParserUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import wanted.commons.core.date.Date;
 import wanted.logic.parser.exceptions.ParseException;
 import wanted.model.loan.Address;
 import wanted.model.loan.Email;
@@ -27,6 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
+    private static final String VALID_DATE = "1 Jan 2025";
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
@@ -54,6 +56,24 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+    }
+
+    @Test
+    public void parseDate_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDate((String) null));
+    }
+
+    @Test
+    public void parseDate_validValueWithoutWhitespace_returnsDate() throws Exception {
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
+        String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
     }
 
     @Test


### PR DESCRIPTION
Added a new class `commons.core.date.Date` to handle dates and a corresponding date parser `parseDate` in `logic.parser.ParserUtil`.

Date is currently stored as a row string, which is just for MVP version and should be modified later.