### PR TITLE
Disable unecessary commands(find and edit)

### DIFF
--- a/src/main/java/wanted/logic/Messages.java
+++ b/src/main/java/wanted/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-
+    public static final String MESSAGE_COMMAND_DISABLED = "This command is disabled in the MVP";
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/wanted/logic/commands/EditCommand.java
+++ b/src/main/java/wanted/logic/commands/EditCommand.java
@@ -69,9 +69,6 @@ public class EditCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        if (!IS_ENABLED) {
-            return new CommandResult(Messages.MESSAGE_COMMAND_DISABLED);
-        }
         requireNonNull(model);
         List<Loan> lastShownList = model.getFilteredPersonList();
 

--- a/src/main/java/wanted/logic/commands/EditCommand.java
+++ b/src/main/java/wanted/logic/commands/EditCommand.java
@@ -31,6 +31,8 @@ import wanted.model.tag.Tag;
  */
 public class EditCommand extends Command {
 
+    public static final boolean IS_ENABLED = false;
+
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the loan identified "
@@ -67,6 +69,9 @@ public class EditCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        if (!IS_ENABLED) {
+            return new CommandResult(Messages.MESSAGE_COMMAND_DISABLED);
+        }
         requireNonNull(model);
         List<Loan> lastShownList = model.getFilteredPersonList();
 

--- a/src/main/java/wanted/logic/commands/FindCommand.java
+++ b/src/main/java/wanted/logic/commands/FindCommand.java
@@ -30,9 +30,6 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        if (!IS_ENABLED) {
-            return new CommandResult(Messages.MESSAGE_COMMAND_DISABLED);
-        }
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(

--- a/src/main/java/wanted/logic/commands/FindCommand.java
+++ b/src/main/java/wanted/logic/commands/FindCommand.java
@@ -13,6 +13,8 @@ import wanted.model.loan.NameContainsKeywordsPredicate;
  */
 public class FindCommand extends Command {
 
+    public static final boolean IS_ENABLED = false;
+
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
@@ -28,6 +30,9 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
+        if (!IS_ENABLED) {
+            return new CommandResult(Messages.MESSAGE_COMMAND_DISABLED);
+        }
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(

--- a/src/main/java/wanted/logic/parser/EditCommandParser.java
+++ b/src/main/java/wanted/logic/parser/EditCommandParser.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import wanted.commons.core.datatypes.Index;
+import wanted.logic.Messages;
 import wanted.logic.commands.EditCommand;
 import wanted.logic.commands.EditCommand.EditPersonDescriptor;
 import wanted.logic.parser.exceptions.ParseException;
@@ -29,6 +30,9 @@ public class EditCommandParser implements Parser<EditCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
+        if (!EditCommand.IS_ENABLED) {
+            throw new ParseException(Messages.MESSAGE_COMMAND_DISABLED);
+        }
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_AMOUNT, PREFIX_DATE);

--- a/src/main/java/wanted/logic/parser/FindCommandParser.java
+++ b/src/main/java/wanted/logic/parser/FindCommandParser.java
@@ -5,7 +5,6 @@ import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import java.util.Arrays;
 
 import wanted.logic.Messages;
-import wanted.logic.commands.EditCommand;
 import wanted.logic.commands.FindCommand;
 import wanted.logic.parser.exceptions.ParseException;
 import wanted.model.loan.NameContainsKeywordsPredicate;

--- a/src/main/java/wanted/logic/parser/FindCommandParser.java
+++ b/src/main/java/wanted/logic/parser/FindCommandParser.java
@@ -4,6 +4,8 @@ import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
+import wanted.logic.Messages;
+import wanted.logic.commands.EditCommand;
 import wanted.logic.commands.FindCommand;
 import wanted.logic.parser.exceptions.ParseException;
 import wanted.model.loan.NameContainsKeywordsPredicate;
@@ -19,6 +21,9 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        if (!FindCommand.IS_ENABLED) {
+            throw new ParseException(Messages.MESSAGE_COMMAND_DISABLED);
+        }
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/test/java/wanted/logic/commands/EditCommandTest.java
+++ b/src/test/java/wanted/logic/commands/EditCommandTest.java
@@ -3,6 +3,7 @@ package wanted.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.commands.CommandTestUtil.DESC_AMY;
 import static wanted.logic.commands.CommandTestUtil.DESC_BOB;
 import static wanted.logic.commands.CommandTestUtil.VALID_AMOUNT_BOB;
@@ -30,13 +31,19 @@ import wanted.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
+ * This command is disabled in the MVP
  */
 public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
+    public void execute_whileDisabled() {
+
+    }
+    @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Loan editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
@@ -51,6 +58,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Loan lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
 
@@ -72,6 +80,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Loan editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
@@ -84,6 +93,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Loan personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -101,6 +111,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Loan firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
@@ -110,6 +121,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         // edit loan in filtered list into a duplicate in address book
@@ -122,6 +134,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
@@ -135,6 +148,7 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
         // ensures that outOfBoundIndex is still in bounds of address book list
@@ -148,6 +162,7 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
+        assumeTrue(EditCommand.IS_ENABLED);
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
@@ -173,6 +188,7 @@ public class EditCommandTest {
 
     @Test
     public void toStringMethod() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Index index = Index.fromOneBased(1);
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         EditCommand editCommand = new EditCommand(index, editPersonDescriptor);

--- a/src/test/java/wanted/logic/commands/FindCommandTest.java
+++ b/src/test/java/wanted/logic/commands/FindCommandTest.java
@@ -3,6 +3,7 @@ package wanted.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static wanted.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static wanted.testutil.TypicalPersons.CARL;
@@ -22,6 +23,7 @@ import wanted.model.loan.NameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ * This command is disabled in the MVP
  */
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -56,6 +58,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
+        assumeTrue(FindCommand.IS_ENABLED);
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
@@ -66,6 +69,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
+        assumeTrue(FindCommand.IS_ENABLED);
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
@@ -76,6 +80,7 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
+        assumeTrue(FindCommand.IS_ENABLED);
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";

--- a/src/test/java/wanted/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/wanted/logic/parser/AddressBookParserTest.java
@@ -2,6 +2,7 @@ package wanted.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wanted.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static wanted.testutil.Assert.assertThrows;
@@ -55,6 +56,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_edit() throws Exception {
+        assumeTrue(EditCommand.IS_ENABLED);
         Loan person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
@@ -70,6 +72,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
+        assumeTrue(FindCommand.IS_ENABLED);
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));

--- a/src/test/java/wanted/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/wanted/logic/parser/EditCommandParserTest.java
@@ -1,5 +1,6 @@
 package wanted.logic.parser;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wanted.logic.commands.CommandTestUtil.AMOUNT_DESC_AMY;
@@ -193,5 +194,11 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+    @Test
+    public void parse_disablecCommand_failure() {
+        assumeFalse(EditCommand.IS_ENABLED);
+        String userInput = "edit";
+        assertParseFailure(parser, userInput, Messages.MESSAGE_COMMAND_DISABLED);
     }
 }

--- a/src/test/java/wanted/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/wanted/logic/parser/EditCommandParserTest.java
@@ -1,5 +1,6 @@
 package wanted.logic.parser;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wanted.logic.commands.CommandTestUtil.AMOUNT_DESC_AMY;
 import static wanted.logic.commands.CommandTestUtil.AMOUNT_DESC_BOB;
@@ -35,6 +36,9 @@ import wanted.model.loan.Name;
 import wanted.model.tag.Tag;
 import wanted.testutil.EditPersonDescriptorBuilder;
 
+/**
+ * Note this is disabled in the MVP
+ */
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
@@ -46,6 +50,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         // no index specified
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
@@ -58,6 +63,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidPreamble_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         // negative index
         assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
@@ -73,6 +79,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
@@ -89,6 +96,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Index targetIndex = INDEX_SECOND_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_DESC_HUSBAND + NAME_DESC_AMY + TAG_DESC_FRIEND
                 + AMOUNT_DESC_AMY + DATE_DESC_AMY;
@@ -103,6 +111,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + AMOUNT_DESC_AMY + DATE_DESC_AMY;
 
@@ -115,6 +124,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_oneFieldSpecified_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         // name
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
@@ -142,6 +152,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_failure() {
+        assumeTrue(EditCommand.IS_ENABLED);
         // More extensive testing of duplicate parameter detections is done in
         // AddCommandParserTest#parse_repeatedNonTagValue_failure()
 
@@ -174,6 +185,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
+        assumeTrue(EditCommand.IS_ENABLED);
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 

--- a/src/test/java/wanted/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/wanted/logic/parser/FindCommandParserTest.java
@@ -1,5 +1,6 @@
 package wanted.logic.parser;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wanted.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static wanted.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -11,17 +12,23 @@ import org.junit.jupiter.api.Test;
 import wanted.logic.commands.FindCommand;
 import wanted.model.loan.NameContainsKeywordsPredicate;
 
+/**
+ * Note this is disabled in the MVP
+ */
+
 public class FindCommandParserTest {
 
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
+        assumeTrue(FindCommand.IS_ENABLED);
         assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
+        assumeTrue(FindCommand.IS_ENABLED);
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));

--- a/src/test/java/wanted/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/wanted/logic/parser/FindCommandParserTest.java
@@ -1,5 +1,6 @@
 package wanted.logic.parser;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static wanted.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static wanted.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -9,6 +10,8 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import wanted.logic.Messages;
+import wanted.logic.commands.EditCommand;
 import wanted.logic.commands.FindCommand;
 import wanted.model.loan.NameContainsKeywordsPredicate;
 
@@ -36,6 +39,13 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_disabledCommand_failure() {
+        assumeFalse(FindCommand.IS_ENABLED);
+        String userInput = "find";
+        assertParseFailure(parser, userInput, Messages.MESSAGE_COMMAND_DISABLED);
     }
 
 }

--- a/src/test/java/wanted/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/wanted/logic/parser/FindCommandParserTest.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import wanted.logic.Messages;
-import wanted.logic.commands.EditCommand;
 import wanted.logic.commands.FindCommand;
 import wanted.model.loan.NameContainsKeywordsPredicate;
 

--- a/src/test/java/wanted/model/AddressBookTest.java
+++ b/src/test/java/wanted/model/AddressBookTest.java
@@ -67,7 +67,7 @@ public class AddressBookTest {
         assertTrue(addressBook.hasPerson(ALICE));
     }
 
-    //TODO: hashasPerson_personWithSameIdentityFieldsInAddressBook_returnsTrue should be updated
+    //TODO: Person_personWithSameIdentityFieldsInAddressBook_returnsTrue should be updated
     @Test
     public void hasPerson_personWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);

--- a/src/test/java/wanted/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/wanted/testutil/EditPersonDescriptorBuilder.java
@@ -13,6 +13,7 @@ import wanted.model.tag.Tag;
 
 /**
  * A utility class to help with building EditPersonDescriptor objects.
+ * This is disabled in the MVP
  */
 public class EditPersonDescriptorBuilder {
 


### PR DESCRIPTION
When a user types in find or edit (regardless of whitespace/arguments afterwards) a "Command is disabled in the MVP" message is returned. 

Added assumeTrue() to test files to ignore EditCommand and FindCommand tests for now. 