### PR TITLE
Fix broken style on User Guide page caused by indentatation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,7 +1,7 @@
 ---
   layout: default.md
-    title: "User Guide"
-    pageNav: 3
+  title: "User Guide"
+  pageNav: 3
 ---
 
 # Wanted User Guide


### PR DESCRIPTION
Note to all: Don't mess with the indentation of the header lines. Seems like the extra indenting broke the table of contents from being generated correctly this morning.