### PR TITLE
Unchanged fields detection in Edithist and Rename commands

### DIFF
--- a/src/main/java/wanted/logic/commands/EdithistCommand.java
+++ b/src/main/java/wanted/logic/commands/EdithistCommand.java
@@ -44,6 +44,8 @@ public class EdithistCommand extends Command {
 
     public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Loan successfully updated: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_UNCHANGED_AMOUNT = "New amount must be different from the old one.";
+    public static final String MESSAGE_UNCHANGED_DATE = "New date must be different from the old one.";
 
     private final Index loanIndex;
     private final Index transactionIndex;
@@ -104,8 +106,18 @@ public class EdithistCommand extends Command {
      * edited with {@code editPersonDescriptor}.
      */
     private static LoanTransaction createEditedTransaction(LoanTransaction transactionToEdit,
-                                                           EditTransactionDescriptor editTransactionDescriptor) {
+                                                           EditTransactionDescriptor editTransactionDescriptor)
+            throws CommandException {
         assert transactionToEdit != null;
+
+        if (editTransactionDescriptor.getAmount().isPresent()
+                && editTransactionDescriptor.getAmount().get().equals(transactionToEdit.getAmount())) {
+            throw new CommandException(MESSAGE_UNCHANGED_AMOUNT);
+        }
+        if (editTransactionDescriptor.getDate().isPresent()
+                && editTransactionDescriptor.getDate().get().equals(transactionToEdit.getDate())) {
+            throw new CommandException(MESSAGE_UNCHANGED_DATE);
+        }
 
         MoneyInt updatedAmount = editTransactionDescriptor.getAmount().orElse(transactionToEdit.getAmount());
         LoanDate updatedDate = editTransactionDescriptor.getDate().orElse(transactionToEdit.getDate());

--- a/src/main/java/wanted/logic/commands/PhoneCommand.java
+++ b/src/main/java/wanted/logic/commands/PhoneCommand.java
@@ -19,7 +19,7 @@ import wanted.model.loan.exceptions.PhoneUnchangedException;
 public class PhoneCommand extends Command {
     public static final String COMMAND_WORD = "phone";
     public static final String MESSAGE_UPDATED_SUCCESS = "Phone number successfully updated: %1$s";
-    public static final String MESSAGE_DELETED_SUCCESS = "Phone number sucessfully deleted: %1$s";
+    public static final String MESSAGE_DELETED_SUCCESS = "Phone number successfully deleted: %1$s";
     public static final String MESSAGE_DUPLICATE_PHONE = "New phone number must be different than the old one";
     public static final String DELETE_WORD = "delete";
 

--- a/src/main/java/wanted/logic/commands/PhoneCommand.java
+++ b/src/main/java/wanted/logic/commands/PhoneCommand.java
@@ -20,7 +20,7 @@ public class PhoneCommand extends Command {
     public static final String COMMAND_WORD = "phone";
     public static final String MESSAGE_UPDATED_SUCCESS = "Phone number successfully updated: %1$s";
     public static final String MESSAGE_DELETED_SUCCESS = "Phone number successfully deleted: %1$s";
-    public static final String MESSAGE_DUPLICATE_PHONE = "New phone number must be different than the old one";
+    public static final String MESSAGE_DUPLICATE_PHONE = "New phone number must be different from the old one.";
     public static final String DELETE_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD

--- a/src/main/java/wanted/logic/commands/RenameCommand.java
+++ b/src/main/java/wanted/logic/commands/RenameCommand.java
@@ -29,6 +29,7 @@ public class RenameCommand extends Command {
     public static final String MESSAGE_RENAME_SUCCESS = "Edited loan name: %1$s";
     public static final String MESSAGE_NOT_EDITED = "The name field must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the loan book.";
+    public static final String MESSAGE_UNCHANGED_NAME = "New amount must be different from the old one.";
 
     private final Index index;
     private final BaseEdit.EditLoanDescriptor editLoanDescriptor;
@@ -53,6 +54,10 @@ public class RenameCommand extends Command {
 
         Loan personToEdit = lastShownList.get(index.getZeroBased());
         Loan editedPerson = BaseEdit.createEditedLoan(personToEdit, editLoanDescriptor);
+
+        if (personToEdit.equals(editedPerson)) {
+            throw new CommandException(MESSAGE_UNCHANGED_NAME);
+        }
 
         if (!personToEdit.equals(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/test/java/wanted/logic/commands/EdithistCommandTest.java
+++ b/src/test/java/wanted/logic/commands/EdithistCommandTest.java
@@ -8,6 +8,8 @@ import static wanted.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static wanted.logic.Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 import static wanted.logic.commands.EdithistCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS;
 import static wanted.logic.commands.EdithistCommand.MESSAGE_NOT_EDITED;
+import static wanted.logic.commands.EdithistCommand.MESSAGE_UNCHANGED_AMOUNT;
+import static wanted.logic.commands.EdithistCommand.MESSAGE_UNCHANGED_DATE;
 import static wanted.testutil.Assert.assertThrows;
 import static wanted.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static wanted.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -136,6 +138,42 @@ public class EdithistCommandTest {
         EdithistCommand edithistCommand =
                 new EdithistCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON, new EditTransactionDescriptor());
         assertThrows(CommandException.class, MESSAGE_NOT_EDITED, () -> edithistCommand.execute(sampleModel));
+    }
+
+    @Test
+    public void execute_unchangedAmount_throwsCommandException() {
+        Model sampleModel = createSampleModel();
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor(editTransactionDescriptor[2]);
+        descriptor.setAmount(sampleModel.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getLoanAmount()
+                .getTransactionHistoryCopy().get(INDEX_FIRST_PERSON.getZeroBased()).getAmount());
+        EdithistCommand edithistCommand =
+                new EdithistCommand(INDEX_SECOND_PERSON, INDEX_FIRST_PERSON, descriptor);
+        assertThrows(CommandException.class, MESSAGE_UNCHANGED_AMOUNT, () -> edithistCommand.execute(sampleModel));
+    }
+
+    @Test
+    public void execute_unchangedDate_throwsCommandException() {
+        Model sampleModel = createSampleModel();
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor(editTransactionDescriptor[2]);
+        descriptor.setDate(sampleModel.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getLoanAmount()
+                .getTransactionHistoryCopy().get(INDEX_FIRST_PERSON.getZeroBased()).getDate());
+        EdithistCommand edithistCommand =
+                new EdithistCommand(INDEX_SECOND_PERSON, INDEX_FIRST_PERSON, descriptor);
+        assertThrows(CommandException.class, MESSAGE_UNCHANGED_DATE, () -> edithistCommand.execute(sampleModel));
+    }
+
+    // both unchanged -> point out unchanged amount
+    @Test
+    public void execute_unchangedAmountAndDate_throwsCommandException() {
+        Model sampleModel = createSampleModel();
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor(editTransactionDescriptor[2]);
+        descriptor.setAmount(sampleModel.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getLoanAmount()
+                .getTransactionHistoryCopy().get(INDEX_FIRST_PERSON.getZeroBased()).getAmount());
+        descriptor.setDate(sampleModel.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getLoanAmount()
+                .getTransactionHistoryCopy().get(INDEX_FIRST_PERSON.getZeroBased()).getDate());
+        EdithistCommand edithistCommand =
+                new EdithistCommand(INDEX_SECOND_PERSON, INDEX_FIRST_PERSON, descriptor);
+        assertThrows(CommandException.class, MESSAGE_UNCHANGED_AMOUNT, () -> edithistCommand.execute(sampleModel));
     }
 
     @Test

--- a/src/test/java/wanted/logic/commands/RenameCommandTest.java
+++ b/src/test/java/wanted/logic/commands/RenameCommandTest.java
@@ -73,6 +73,16 @@ class RenameCommandTest {
     }
 
     @Test
+    public void execute_unchangedName_failure() {
+        Loan firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        BaseEdit.EditLoanDescriptor descriptor =
+                new EditLoanDescriptorBuilder().withName(firstPerson.getName().fullName).build();
+        RenameCommand renameCommand = new RenameCommand(INDEX_FIRST_PERSON, descriptor);
+
+        assertCommandFailure(renameCommand, model, RenameCommand.MESSAGE_UNCHANGED_NAME);
+    }
+
+    @Test
     public void execute_duplicatePersonFilteredList_failure() throws ExcessRepaymentException {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 


### PR DESCRIPTION
Made Edithist and Rename commands output an error message when input fields coincide with the current values.

Total lines of modified functional codes: 23