### PR TITLE
Tag command fix

### DIFF
--- a/src/main/java/wanted/logic/commands/BaseEdit.java
+++ b/src/main/java/wanted/logic/commands/BaseEdit.java
@@ -30,7 +30,8 @@ public final class BaseEdit {
         assert loanToEdit != null;
         Name updatedName = editDescriptor.getName().orElse(loanToEdit.getName());
         LoanAmount updatedAmount = editDescriptor.getAmount().orElse(loanToEdit.getLoanAmount());
-        Set<Tag> updatedTags = editDescriptor.getTags().orElse(loanToEdit.getTags());
+        Set<Tag> previousTags = loanToEdit.getTags();
+        Set<Tag> updatedTags = editDescriptor.getTags(previousTags).orElse(loanToEdit.getTags());
 
         return new Loan(updatedName, updatedAmount, updatedTags);
     }
@@ -90,12 +91,31 @@ public final class BaseEdit {
         }
 
         /**
+         * Merges a set of tags with the object's {@code tags}
+         */
+        public void appendTags(Set<Tag> tags) {
+            assert this.tags != null : "null tags should reset all tags";
+            Set<Tag> modifiedTags = new HashSet<>(tags);
+            modifiedTags.addAll(this.tags);
+            this.tags = modifiedTags;
+        }
+
+        /**
          * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code tags} is null.
          */
-        public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        public Optional<Set<Tag>> getTags(Set<Tag> previousTags) {
+            if (this.tags == null) {
+                return Optional.empty();
+            }
+            if (this.tags.isEmpty()) {
+                return Optional.of(Collections.unmodifiableSet(new HashSet<>())); // empty input t/
+            }
+            if (previousTags != null) {
+                appendTags(previousTags); //when there is previous input
+            }
+            return Optional.of(Collections.unmodifiableSet(tags));
         }
 
         @Override

--- a/src/main/java/wanted/logic/commands/TagCommand.java
+++ b/src/main/java/wanted/logic/commands/TagCommand.java
@@ -29,7 +29,8 @@ public class TagCommand extends Command {
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
-    public static final String MESSAGE_RENAME_SUCCESS = "Edited loan name: %1$s";
+    public static final String MESSAGE_TAG_SUCCESS = "Edited loan tags: %1$s";
+    public static final String MESSAGE_DUPLICATE_TAG = "Your requested tag(s) already exist(s) for:\n %1$s";
     private final Index index;
     private final BaseEdit.EditLoanDescriptor editLoanDescriptor;
 
@@ -53,12 +54,15 @@ public class TagCommand extends Command {
 
         Loan personToEdit = lastShownList.get(index.getZeroBased());
         Loan editedPerson = BaseEdit.createEditedLoan(personToEdit, editLoanDescriptor);
+        if (!editedPerson.getTags().isEmpty() && personToEdit.getTags().containsAll(editedPerson.getTags())) {
+            return new CommandResult(String.format(MESSAGE_DUPLICATE_TAG, Messages.format(editedPerson)));
+        }
 
         //removed check for isSamePerson since name identity remains the same
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_RENAME_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_TAG_SUCCESS, Messages.format(editedPerson)));
     }
 
 }

--- a/src/main/java/wanted/logic/commands/TagCommand.java
+++ b/src/main/java/wanted/logic/commands/TagCommand.java
@@ -30,7 +30,7 @@ public class TagCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_TAG_SUCCESS = "Edited loan tags: %1$s";
-    public static final String MESSAGE_DUPLICATE_TAG = "Your requested tag(s) already exist(s) for:\n %1$s";
+    public static final String MESSAGE_DUPLICATE_TAG = "Your requested tag(s) already exist(s) for this person";
     private final Index index;
     private final BaseEdit.EditLoanDescriptor editLoanDescriptor;
 
@@ -55,7 +55,7 @@ public class TagCommand extends Command {
         Loan personToEdit = lastShownList.get(index.getZeroBased());
         Loan editedPerson = BaseEdit.createEditedLoan(personToEdit, editLoanDescriptor);
         if (!editedPerson.getTags().isEmpty() && personToEdit.getTags().containsAll(editedPerson.getTags())) {
-            return new CommandResult(String.format(MESSAGE_DUPLICATE_TAG, Messages.format(editedPerson)));
+            throw new CommandException(MESSAGE_DUPLICATE_TAG);
         }
 
         //removed check for isSamePerson since name identity remains the same
@@ -64,6 +64,22 @@ public class TagCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_TAG_SUCCESS, Messages.format(editedPerson)));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof TagCommand)) {
+            return false;
+        }
+
+        TagCommand otherCommand = (TagCommand) other;
+        return index.equals(otherCommand.index)
+                && editLoanDescriptor.equals(otherCommand.editLoanDescriptor);
+    }
+
 
 }
 

--- a/src/main/java/wanted/model/tag/Tag.java
+++ b/src/main/java/wanted/model/tag/Tag.java
@@ -59,4 +59,8 @@ public class Tag {
         return '[' + tagName + ']';
     }
 
+    public String getTagName() {
+        return tagName;
+    }
+
 }

--- a/src/test/java/wanted/logic/commands/EditLoanDescriptorTest.java
+++ b/src/test/java/wanted/logic/commands/EditLoanDescriptorTest.java
@@ -7,10 +7,15 @@ import static wanted.logic.commands.CommandTestUtil.NEW_DESC_AMY;
 import static wanted.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static wanted.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import wanted.model.loan.exceptions.ExcessRepaymentException;
+import wanted.model.tag.Tag;
 import wanted.testutil.EditLoanDescriptorBuilder;
+
 
 public class EditLoanDescriptorTest {
 
@@ -44,10 +49,11 @@ public class EditLoanDescriptorTest {
 
     @Test
     public void toStringMethod() {
+        Set<Tag> exampleTags = new HashSet<>(); //example tag
         BaseEdit.EditLoanDescriptor editLoanDescriptor = new BaseEdit.EditLoanDescriptor();
         String expected = BaseEdit.EditLoanDescriptor.class.getCanonicalName() + "{name="
                 + editLoanDescriptor.getName().orElse(null) + ", tags="
-                + editLoanDescriptor.getTags().orElse(null) + ", amount="
+                + editLoanDescriptor.getTags(exampleTags).orElse(null) + ", amount="
                 + editLoanDescriptor.getAmount().orElse(null) + "}";
         assertEquals(expected, editLoanDescriptor.toString());
     }

--- a/src/test/java/wanted/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/wanted/logic/parser/TagCommandParserTest.java
@@ -5,6 +5,7 @@ import static wanted.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static wanted.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static wanted.logic.parser.CliSyntax.PREFIX_TAG;
 import static wanted.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static wanted.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static wanted.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,9 @@ import wanted.logic.commands.BaseEdit;
 import wanted.logic.commands.TagCommand;
 import wanted.testutil.EditLoanDescriptorBuilder;
 
-
 public class TagCommandParserTest {
 
-    private static final String TAG_EMPTY = " " + PREFIX_TAG;
+    private static final String TAG_EMPTY = PREFIX_TAG + " ";
     private static final String INVALID_TAG_COMMAND_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE);
     private TagCommandParser parser = new TagCommandParser();
@@ -52,12 +52,10 @@ public class TagCommandParserTest {
     @Test
     public void parse_resetTags_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
+        String userInput = targetIndex.getOneBased() + " " + TAG_EMPTY;
 
         BaseEdit.EditLoanDescriptor descriptor = new EditLoanDescriptorBuilder().withTags().build();
         TagCommand expectedCommand = new TagCommand(targetIndex, descriptor);
-
-        //assertParseSuccess(parser, userInput, expectedCommand);
-        //have no idea why this doesnt work
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/wanted/testutil/EditLoanDescriptorBuilder.java
+++ b/src/test/java/wanted/testutil/EditLoanDescriptorBuilder.java
@@ -58,6 +58,9 @@ public class EditLoanDescriptorBuilder {
      * that we are building.
      */
     public EditLoanDescriptorBuilder withTags(String... tags) {
+        if (tags.length == 0) {
+            descriptor.setTags(null);
+        }
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
         return this;


### PR DESCRIPTION
1. Allow tags to be added with t/example
2. Delete tags with command t/
3. Identify identical tags, aka, when edited tags are a subset of current tags (note if min 1 edited tag is not a subset of the current taglist, then the edit success message returns)

Lines of functional code changed : 26 

